### PR TITLE
Add new class that can center the h2 elements between the hr elements

### DIFF
--- a/collaboration.html
+++ b/collaboration.html
@@ -48,7 +48,7 @@
 				<div>
 						<br>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="what-is-it-content">What is it?</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="what-is-it-content">What is it?</a></h2>
 						<div id="what-is-it-content" aria-hidden="true">
 							<p class="advisory">Collaboration among agencies is necessary for students and youth who are touched by many systems and professionals. When collaboration is directly focused on outcomes for youth, such as integrated paid employment, and the systems that serve them – rather than merely making a hand-off to the next responsible organization – higher rates of employment are more likely. Conversely, without a focus on developing collaborative relationships efforts falter.</p>
 							<p class="advisory">Collaboration between schools, vocational rehabilitation (VR), and other partners is effective when there is a clear and compelling rationale for staff to work across agency lines (Fabian, in press). Collaboration is structured around formalized relationships and processes that maximize the expertise and perspectives of students, parents, educators, VR counselors, and other partners involved in the transition process. The relationships and processes should promote individualized student services, supports, and activities and roles, and identify responsibilities of each partner designed and focused on providing the identified needs and supports. The most effective teams work to achieve a direct outcome for youth served, rather than simply coordinate a “hand off” to the next available post-secondary service (Simonsen, Fabian, &amp; Luecking, in press).</p>
@@ -58,7 +58,7 @@
 					<hr>
 
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="why-is-it-important-content">Why is it important?</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="why-is-it-important-content">Why is it important?</a></h2>
 						<div id="why-is-it-important-content" aria-hidden="true">
 							<p class="advisory">It has long been held that collaboration among professionals and service systems is an important component of effective initiatives and services that support the transition of youth with disabilities from school to work and adult life (Wehman, 2013). In fact, without clearly identified roles of, and coordination between, involved parties to this transition, there are potential problems at two levels: 1) individual and 2) partner.</p>
 							<ul class="advisory">
@@ -77,7 +77,7 @@
 					<hr>
 
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="how-to-implement-content">How to implement</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="how-to-implement-content">How to implement</a></h2>
 						<div id="how-to-implement-content" aria-hidden="true">
 							<p class="advisory">It is optimal for professionals to work collaboratively when they are providing transition-related services to youth with disabilities through an Interagency team. Effective collaboration begins when all stakeholders involved are identified and begin to work on a common goal for the student transitioning to employment. Through thoughtful and committed partners, significant opportunities can be created so the student is able to gain work experience and paid employment prior to their school exit. Effective collaboration focuses on building a system that facilitates an increase in the employment outcomes of transition-age youth.</p>
 							<p class="advisory">It is logical for school systems or Vocational Rehabilitation to take on a leadership role in convening the partners. When considering which partners need to be involved, the team should consider identifying critical partners to assist secondary students with career development planning, work experiences, and paid employment.  Potential partners to consider include, but are not limited to: vocational rehabilitation, youth development programs, workforce development, employers, parents and adult service providers that offer job development, placement, and support services. For a list of potential partners and their roles and responsibilities see Tool Section: Partner Roles and Responsibilities.</p>
@@ -98,7 +98,7 @@
 					<hr>
 
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="implications-content">Implications for practice</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="implications-content">Implications for practice</a></h2>
 						<div id="implications-content" aria-hidden="true">
 							<p class="advisory"><strong>System level:</strong></p>
 							<ul class="advisory">
@@ -124,7 +124,7 @@
 					<hr>
 
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="roadblocks-content">Potential roadblocks/suggested approaches</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="roadblocks-content">Potential roadblocks/suggested approaches</a></h2>
 						<div id="roadblocks-content" aria-hidden="true">
 							<p class="advisory"><strong>Team members may not understand the roles of adult service agencies and how they connect to transition planning for students.</strong><br><em>Suggested Approaches:</em></p>
 							<ul class="advisory">
@@ -159,7 +159,7 @@
 					<hr>
 
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="tools-content">Tools</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="tools-content">Tools</a></h2>
 						<div id="tools-content" aria-hidden="true">
 							<ul class="advisory">
 								<li><a href="file:///Users/hmasiello/Desktop/DRRP%20Website/DRRP/Links/Collaboration/Tool_Collaboration_Tools_RolesAndResponsibilitiesChart.docx">Role and Responsibilities Chart</a></li>
@@ -171,7 +171,7 @@
 					<hr>
 
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="thinking-points-content">Thinking points</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="thinking-points-content">Thinking points</a></h2>
 						<div id="thinking-points-content" aria-hidden="true">
 							<ul class="advisory">
 								<li>Collaborate around the common outcome of integrated paid employment. Effective teams work together to achieve direct outcomes for youth served, rather than simply making a “hand off” to the next available agency or service.</li>
@@ -183,7 +183,7 @@
 					<hr>
 
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="briefs-content">Briefs</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="briefs-content">Briefs</a></h2>
 						<div id="briefs-content" aria-hidden="true">
 							<ul class="advisory">
 								<li>Does Service Collaboration Enhance Seamless Transition Outcomes?<br><a href="file:///Users/hmasiello/Desktop/DRRP%20Website/DRRP/Links/Collaboration/Brief_Collaboration_DoesServiceCollaborationEnhanceSeamlessTransitionOutcomes_PDF.pdf">PDF</a> | <a href="file:///Users/hmasiello/Desktop/DRRP%20Website/DRRP/Links/Collaboration/Brief_Collaboration_DoesServiceCollaborationEnhanceSeamlessTransitionOutcomesWORD.docx">WORD</a></li>

--- a/css/style.css
+++ b/css/style.css
@@ -226,11 +226,25 @@ em {
 }
 
 /******************************************
-/* ADDITIONAL STYLES
+/* EXPANDING CONTENT
 /*******************************************/
+
+.expandy-title {
+	padding-bottom: 0;
+}
+
+.expandy-title a {
+	/* FIXME:*/
+	/* color: SET_THE_COLOR_YOU_WANT_HERE; */
+}
+
 .toggle {
 	cursor: pointer;
 }
+
+/******************************************
+/* ADDITIONAL STYLES
+/*******************************************/
 
 .advisory {
 	padding-left: 20px;

--- a/employment.html
+++ b/employment.html
@@ -48,7 +48,7 @@
 				<div>
 						<br>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="what-is-it-content">What is it?</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="what-is-it-content">What is it?</a></h2>
 						<div id="what-is-it-content" aria-hidden="true">
 							<p class="advisory">Competitive integrated employment refers to jobs held by people with disabilities in typical workplace settings (not sheltered workshops) where the majority of individuals are not employees with disabilities, where they earn at least minimum wage, and where they are paid directly by the employer. Simply stated, competitive integrated employment is real work for real pay.  To achieve this gold standard of work, families, schools, vocational rehabilitation (VR) agencies and other adult service agencies need to actively collaborate in transition planning for the student. One of the key activities in transition planning is for the student to participate in a paid work experience prior to high school graduation. The importance of paid work experience as a significant predicator of post-school employment for youth with disabilities has been well documented (Carter, Austin, &amp; Trainor, 2012; Gold &amp; Fabian, &amp; Luecking, 2013; Test et al., 2009). Services that include real work experiences as a key intervention component are found to have higher rates of youth transitioning into integrated employment (Luecking &amp; Luecking, 2013). These findings are consistent regardless of disability category, where one lives, or their socio-economic status (Gold, Fabian &amp; Luecking, 2013). Therefore, competitive integrated employment is a realistic and desirable expectation for all youth who choose to work, regardless of disability label or need for accommodation and support.</p>
 							<p class="advisory">Evolving federal transition and disability employment policy increasingly reflects the presumption of employability for all individuals with disabilities. The Ticket to Work and Work Incentives Improvement Act of 1999, the Individuals with Disabilities Education Improvement Act (IDEA) of 2004, and the recently enacted Workforce Innovation and Opportunity Act (WIOA) (2014) are each predicated on the expectation that services delivered through their respective mandates are available to and will benefit all individuals with disabilities to whom the services apply. These policies make employment possible for all categories of youth, regardless of disability, need for support, and economic circumstance.</p>
@@ -57,7 +57,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="why-is-it-content">Why is it important?</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="why-is-it-content">Why is it important?</a></h2>
 						<div id="why-is-it-content" aria-hidden="true">
 							<p class="advisory">Research has demonstrated that employment is associated with an individual’s overall quality of life or assessment of his/her well-being (Canha, Simoes, Owens, 2013). However, employment outcomes of youth with disabilities consistently lag behind those of their non-disabled peers. A Department of Labor report cited that only 26% of youth with disabilities are employed after high school, compared to almost 64% of their nondisabled peers (2013). Additionally, individuals with disabilities experience the highest rates of poverty of any subcategory of Americans charted by the Census Bureau. Alarmingly, 27 %, or more than 4 million, of the nearly 30 million individuals with disabilities ages 18–64 live in poverty, more than double the rate of the entire population in the same age group (Office of Disability Employments Policy, 2013).</p>
 							<a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="why-is-it-content">Read less &gt;</a>
@@ -65,7 +65,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="how-is-it-content">How to implement</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="how-is-it-content">How to implement</a></h2>
 						<div id="how-is-it-content" aria-hidden="true">
 							<p class="advisory">To improve employment outcomes for students with disabilities, there should be clear expectations that all students will have a paid work experience in the community while in high school, whether through the school or by other means. Along with work experiences, vocational training is also an important aspect of transition and should be incorporated into transition planning practices (Wehman, et al., 2014). Encouraging the student to participate in vocational training which aligns with his/her career interests, as well as work-based learning experiences, such as job shadowing, work sampling, volunteer work, and service learning will assist the student in becoming more prepared and knowledgeable about the world of work.</p>
 							<p class="advisory">It is equally  important for staff working with transition-age youth to have the resources and flexibility to continuously develop, maintain, and expand a network of employer contacts from which the youth can access for job interviews, job tours, work experiences, and ultimately, paid employment. Employment specialists need to have opportunities to get to know employers and learn about their hiring practices, job requirements, and special employment concerns. To make this feasible, it is important to allow staff responsible for these tasks to flex their time to meet the needs of employers (e.g., weekend and evening hours).</p>
@@ -74,7 +74,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="implications-content">Implications for practice</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="implications-content">Implications for practice</a></h2>
 						<div id="implications-content" aria-hidden="true">
 							<p class="advisory"><strong>System level:</strong></p>
 							<ul class="advisory">
@@ -97,7 +97,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="potential-content">Potential roadblocks/suggested approaches</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="potential-content">Potential roadblocks/suggested approaches</a></h2>
 						<div id="potential-content" aria-hidden="true">
 							<p class="advisory"><strong>Team members are unsure how to approach businesses for work experience opportunities.</strong><br><em>Suggested Approaches:</em></p>
 							<ul class="advisory">
@@ -115,7 +115,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="tools-content">Tools</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="tools-content">Tools</a></h2>
 						<div id="tools-content" aria-hidden="true">
 							<ul class="advisory">
 							<p><strong>Job Seeker Tools</strong></p>
@@ -146,7 +146,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="thinking-points-content">Thinking points</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="thinking-points-content">Thinking points</a></h2>
 						<div id="thinking-points-content" aria-hidden="true">
 							<ul class="advisory">
 								<li>Adult employment is more likely when students have work experiences and jobs during their secondary school years and when families expect and support employment.</li>
@@ -159,7 +159,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="briefs-content">Briefs</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="briefs-content">Briefs</a></h2>
 						<div id="briefs-content" aria-hidden="true">
 							<ul class="advisory">
 								<li>Evaluating the Implementation and Outcomes of Secondary Supported Employment Programs for Students with Intellectual or Developmental Disabilities<br><a href="file:///Users/hmasiello/Desktop/DRRP%20Website/DRRP/Links/Employment/Brief_EvaluatingForStudentsWithIntellectualOrDevelopmental.pdf">PDF</a> | <a href="file:///Users/hmasiello/Desktop/DRRP%20Website/DRRP/Links/Employment/Brief_EvaluatingForStudentsWithIntellectualOrDevelopmental_WORD.docx">WORD</a></li>
@@ -172,7 +172,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="references-content">References</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="references-content">References</a></h2>
 						<div id="references-content" aria-hidden="true">
 							<p class="advisory">Wehman, P., Sima, A., Ketchum, West, M., &amp; Luecking, R. (2014). Journal of Occupational Rehabilitation</p>
 							<a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="references-content">Read less &gt;</a>

--- a/intervention.html
+++ b/intervention.html
@@ -48,7 +48,7 @@
 				<div>
 						<br>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="what-is-it-content">What is it?</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="what-is-it-content">What is it?</a></h2>
 						<div id="what-is-it-content" aria-hidden="true">
 							<p class="advisory content">Seamless transition can be defined as a sequential delivery of specific preparatory and coordinated services that begin early in high school and continue beyond school exit. Well-designed and consistently delivered services, focused on integrated employment, can lead to improved competitive employment outcomes.</p>
 							<p class="advisory content">Critical components of those services include intentional activities to assess and build career interests, preferences and skills. Work experiences and paid employment needs to be central to the intervention. Services should include job development with employers and opportunities for youth to be exposed to a number of different work experiences that lead to individualized, integrated jobs of their choice.</p>
@@ -58,7 +58,7 @@
 					</div>
 					<hr />
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="why-is-it-content">Why is it important?</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="why-is-it-content">Why is it important?</a></h2>
 						<div id="why-is-it-content" aria-hidden="true">
 							<p class="advisory content">A coherent transition service model, which includes research-supported interventions, allows for a more clearly defined pathway to employment. Work experiences and employment during secondary school years, family expectations and involvement, and direct connections with post-school supports are the key services that lead to a seamless transition for youth with disabilities (Luecking &amp; Luecking, 2013).</p>
 							<p class="advisory content">Transition services that included real work experiences, in local businesses, central to the intervention were found to have higher rates of youth transition into integrated, paid employment (Gold, Fabian, &amp; Luecking 2013; Getzel, Rachel, Lau, 2013; Luecking &amp; Luecking, 2013). This commitment to employment in turn must include earlier and ongoing collaboration among schools, Vocational Rehabilitation, and other adult service agencies in order to meet the employment outcome.</p>
@@ -67,7 +67,7 @@
 					</div>
 					<hr />
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="how-to-implement-content">How to implement</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="how-to-implement-content">How to implement</a></h2>
 						<div id="how-to-implement-content" aria-hidden="true">
 							<p class="advisory content">In order for seamless transition services to build the capacity within the local service delivery systems to better prepare youth with disabilities for competitive, integrated employment, significant time should be spent: 1) defining a systematic flow of services; 2) identifying and connecting with the key partners; and 3) determining the roles and responsibilities of each key partner.  Services need to be coordinated and begin early in high school and continue through post-school follow up supports.</p>
 							<p class="advisory content">In developing a flow of services the following components must be included.</p>
@@ -98,7 +98,7 @@
 					</div>
 					<hr />
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="implications-content">Implications for practice</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="implications-content">Implications for practice</a></h2>
 						<div id="implications-content" aria-hidden="true">
 							<p class="advisory content"><strong>System level:</strong></p>
 							<ul class="advisory content">
@@ -125,7 +125,7 @@
 					</div>
 					<hr />
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="potential-roadblocks-content">Potential roadblocks/suggested approaches</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="potential-roadblocks-content">Potential roadblocks/suggested approaches</a></h2>
 						<div id="potential-roadblocks-content" aria-hidden="true">
 							<p class="advisory content"><strong>Roadblock: Families and students may not be aware of or be connected to services that are necessary to maintain integrated employment after exiting high school.</strong><br><em>Suggested Approaches:</em></p>
 							<ul class="advisory content">
@@ -156,7 +156,7 @@
 					</div>
 					<hr />
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="tools-content">Tools</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="tools-content">Tools</a></h2>
 						<div id="tools-content" aria-hidden="true">
 							<ul class="advisory content">
 								<li><a href="file:///Users/hmasiello/Desktop/DRRP%20Website/DRRP/Links/Intervention/Tool_Collaboration_Tools_FlowOfServiceWorksheet.docx">Flow of Services</a></li>
@@ -167,7 +167,7 @@
 					</div>
 					<hr />
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="thinking-points-content">Thinking points</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="thinking-points-content">Thinking points</a></h2>
 						<div id="thinking-points-content" aria-hidden="true">
 							<ul class="advisory content">
 								<li>Employment-focused interventions that provide substantial amounts of well-designed services can improve key transition outcomes for youth with disabilities.</li>
@@ -179,7 +179,7 @@
 					</div>
 					<hr />
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="briefs-content">Briefs</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="briefs-content">Briefs</a></h2>
 						<div id="briefs-content" aria-hidden="true">
 							<ul class="advisory content">
 								<li>Do Promising Vocational Interventions Benefit At-Risk Youth?<br><a href="file:///Users/hmasiello/Desktop/DRRP%20Website/DRRP/Links/Intervention/Brief_DoPromisingVocationalInterventionsBenefit.pdf">PDF</a> | <a href="file:///Users/hmasiello/Desktop/DRRP%20Website/DRRP/Links/Intervention/Brief_DoPromisingVocationalInterventionsBenefit_WORD.docx">WORD</a></li>
@@ -192,7 +192,7 @@
 					</div>
 					<hr />
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="references-content">References</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="references-content">References</a></h2>
 						<div id="references-content" aria-hidden="true">
 							<p class="advisory content">Wehman, P., Sima, A., Ketchum, West, M., &amp; Luecking, R. (2014). Journal of Occupational Rehabilitation</p>
 							<a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="references-content">Read less &gt;</a>

--- a/skilledprofessional.html
+++ b/skilledprofessional.html
@@ -48,7 +48,7 @@
 				<div>
 						<br>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="what-is-it-content">What is it?</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="what-is-it-content">What is it?</a></h2>
 						<div id="what-is-it-content" aria-hidden="true">
 							<p class="advisory content">Transition specialists play a critical role in assisting youth with disabilities transition to paid integrated employment.  These individuals are housed in schools, community rehabilitation organizations, vocational rehabilitation, and other state agencies. The Center on Transition to Employment (The Center) identified four personal attributes that were found in effective transition specialists.  These traits are: 1) principled optimism, 2) cultural competence, 3) business oriented professionalism and 4) networking savvy (Tilson &amp; Simonsen, 2012).</p>
 							<p class="advisory content">Transition specialists displaying these four attribute believe in the capabilities of the youth with whom they worked and empowered them to be their best.  They didn’t look at what the youth could not do, but rather at the positive attributes, and identified the benefits they could bring to employers.  The transition specialists took into account the uniqueness of each of the youth they supported, as well as the specific needs of the employers they worked with.  By understanding the needs of both, the job seeker and the employer, they identified connections between the two, resulting in good job matches that satisfied employers and youth.</p>
@@ -58,7 +58,7 @@
 					</div>
 					<hr />
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="why-is-it-content">Why is it important?</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="why-is-it-content">Why is it important?</a></h2>
 						<div id="why-is-it-content" aria-hidden="true">
 							<p class="advisory content">Despite years of research, legislation and implementation of new policies and programs, students with disabilities are still not achieving the same level of post school outcomes as their non-disabled peers.  A 2013 report from the U.S. Department of Labor indicated that only 26% of job seekers with disabilities were employed after high school compared to almost 64% of job seekers without disabilities. Research also shows that one of the most consistent predictors of post-school employment success is a paid work experience while in high school, where the job seekers are integrated into authentic work places alongside co-workers without disabilities. Work experiences, particularly paid work, prior to exit from secondary school leads to improved transition experiences and post-school outcomes (Fabian, 2007; Luecking, 2009; Test et. al., 2009). These findings are consistent regardless of disability category, where one lives, or their socio-economic status (Gold, Fabian, &amp; Luecking, 2013). </p>
 							<p class="advisory content">In most cases, transition specialists are the professionals who are required to assess the skills of students, create relationships with community employers, assist in matching students with work opportunities, and identify/arrange work place supports for the student, as needed. Based on the critical role that transition specialist’s play in the success of youth with disabilities becoming employed, understanding the personal attributes of effective transition specialists is important. Agencies or schools can design the best transition programs or services, but without effective staff to implement the services, the results of those programs may be limited. </p>
@@ -67,7 +67,7 @@
 					</div>
 					<hr />
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="how-to-implement-content">How to implement</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="how-to-implement-content">How to implement</a></h2>
 						<div id="how-to-implement-content" aria-hidden="true">
 							<p class="advisory content">The key to having competent employees is implementing an effective recruitment and training process. When managers understand the personal attributes of effective transition specialists, they can target their recruitment efforts towards individuals who possess these characteristics.  Additionally, as staff are hired, professional development opportunities should focus on enhancing and building skills that are commonly found in employment specialists with these attributes.</p>
 							<p class="advisory content">Individuals interested in entering the field of transition need to have a clear understanding of the personal attributes  that are required to be effective in their role. Effective transition specialists focus on securing employment for youth with disabilities and conducting outreach to employers.  Regardless of an applicant’s specific work history, it is critical that hiring practices seek to find individuals who have the interest and are capable of acquiring the specific professional competencies that lead to successful employment outcomes for youth with disabilities.</p>
@@ -102,7 +102,7 @@
 					</div>
 					<hr />
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="implicatinos-content">Implications for practice</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="implicatinos-content">Implications for practice</a></h2>
 						<div id="implicatinos-content" aria-hidden="true">
 							<ul class="advisory content">
 								<li>There are traits professionals have that can be identified and encouraged that will make them especially effective in facilitating competitive integrated employment (Tilson &amp; Simonsen, 2012).</li>
@@ -115,7 +115,7 @@
 					</div>
 					<hr />
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="potential-roadblocks-content">Potential roadblocks/suggested approaches</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="potential-roadblocks-content">Potential roadblocks/suggested approaches</a></h2>
 						<div id="potential-roadblocks-content" aria-hidden="true">
 							<p class="advisory content"><strong>Employment programs staffed with individuals from traditional social service backgrounds may spend more time on general case management duties that divert staff away from the challenging yet ultimately more productive activities of job development and job placement.</strong><br><em>Suggested Approaches:</em></p>
 							<ul class="advisory content">
@@ -134,7 +134,7 @@
 					</div>
 					<hr />
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="tools-content">Tools</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="tools-content">Tools</a></h2>
 						<div id="tools-content" aria-hidden="true">
 							<ul class="advisory content">
 								<li><a href="file:///Users/hmasiello/Desktop/DRRP%20Website/DRRP/Links/Collaboration/Tool_SkilledProfessional_Tool_InformationalInterviewSiteVisitForm.docx">Informational Interview</a></li>
@@ -144,7 +144,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="thinking-points-content">Thinking points</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="thinking-points-content">Thinking points</a></h2>
 						<div id="thinking-points-content" aria-hidden="true">
 							<ul class="advisory content">
 								<li>Collaborate around the common outcome of integrated paid employment. Effective teams work together to achieve direct outcomes for youth served, rather than simply making a “hand off” to the next available agency or service.</li>
@@ -155,7 +155,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="briefs-content">Briefs</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="briefs-content">Briefs</a></h2>
 						<div id="briefs-content" aria-hidden="true">
 							<ul class="advisory content">
 								<li>Employer Preferences in Hiring Youth with Disabilities<br><a href="file:///Users/hmasiello/Desktop/DRRP%20Website/DRRP/Links/SkilledProfessional/Brief_EmployerPreferencesInHiringYouth.pdf">PDF</a> | <a href="file:///Users/hmasiello/Desktop/DRRP%20Website/DRRP/Links/SkilledProfessional/Brief_EmployerPreferencesInHiringYouth_WORD.docx">WORD</a></li>

--- a/toolkit.html
+++ b/toolkit.html
@@ -47,7 +47,7 @@
 				<div>
 					<div class="container">
 						<br>
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="introductions-content">Introduction</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="introductions-content">Introduction</a></h2>
 						<div id="introductions-content" aria-hidden="true">
 							<p class="advisory">Wouldn’t it be ideal if the culmination of secondary education for all students and youth with disabilities was a job and a clear career path? That is, as youth make the transition from being students to young adults the ideal would be that they move  seamlessly from being a student to being an employed young adult and/or to being an enrollee in post-secondary education and training that will lead to a meaningful job and career.  This is indeed the “gold standard” of transition outcomes. The activities of transition and employment initiatives, and the partnerships that support them, are most appropriately judged against this standard.</p>
 							<p class="advisory">With what we now know, there is no reason not to expect this to be the desired outcome for every student who receives special education services in today’s high schools. In fact, there is an increasing body of research that suggest that not only can this be the prevailing norm, but we are becoming increasingly aware of what makes this possible for every student and youth, regardless of the disability label, the nature of the disability, and the need for support and accommodation.</p>
@@ -58,7 +58,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="what-is-seamless">What is Seamless Transition?</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="what-is-seamless">What is Seamless Transition?</a></h2>
 						<div id="what-is-seamless" aria-hidden="true">
 							<p class="advisory">The concept of seamless transition for this Toolkit borrows from the Transition Services Integration Model (TSIM) originally implemented by Certo, Luecking, et al. (2009) which endeavors to integrate services at the point of transition so that the first day after school exit looks no different than the last day of school. That is, students exit school already in a job, with supports in place to keep this job and to pursue new jobs and career advancement throughout their adult life.  Thus, we refer to the move from school to employment and adult life as “seamless” because there is no interruption of service and support after school exit to maintain employment.</p>
 							<p class="advisory">While TSIM addresses services integrated during the final year in school, the research of the Center had identified additional elements that begin much earlier in high school and that include important components that contribute to successful seamless transition. It also broadens the concept of “seamless-ness” to include the uninterrupted movement from secondary school to other activities designed to lead to post-secondary jobs and careers, including post-secondary education, occupational training, and linkages to services designed to facilitate adult employment.</p>
@@ -70,7 +70,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="what-makes-successful">What makes successful transition to employment happen?</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="what-makes-successful">What makes successful transition to employment happen?</a></h2>
 						<div id="what-makes-successful" aria-hidden="true">
 							<p class="advisory">Here's what contemporary research says:</p>
 							<ul class="advisory">
@@ -87,7 +87,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2 class="advisory"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="work-is-the-reason">Work is the reason!</a></h2>
+						<h2 class="advisory expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="work-is-the-reason">Work is the reason!</a></h2>
 						<div id="work-is-the-reason" aria-hidden="true">
 							<p class="advisory">Work experience in high school is the most important factor in predicting adult employment. For example, Sima, et al. (2014) examined the data from the National Longitudinal Study 2. They found that those youth who were employed for pay in high school were universally more likely to be employed at the later point than those who were not employed, with the percentage of employment ranging from 61.6% to 88.5%. Additionally, family expectations of work contributed to increased prospects of post school employment. Moreover, they found that even youth considered “at risk” of poor employment outcomes are likely to achieve employment under circumstances of exposure to work in high school (Sima, West, et al, 2014).</p>
 							<p class="advisory">Similarly, Gold, Fabian &amp; Luecking (2014) found that in a national youth employment program operated by the Marriott Foundation for People with Disabilities (MFPD) over 80% of participating youth with a range of disabilities achieved successful employment. MFPD’s program, called <em>Bridges… from school to work</em>, or simply <em>Bridges</em>, achieved these results in programs operated in primarily urban areas serving predominantly minority youth. In addition, these outcomes were consistent regardless of the economic effect of the recent Great Recession in the respective cities where <em>Bridges</em> operates.</p>
@@ -99,7 +99,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2 class="advisory"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="collaboration">Collaboration is necessary for many youth</a></h2>
+						<h2 class="advisory expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="collaboration">Collaboration is necessary for many youth</a></h2>
 						<div id="collaboration" aria-hidden="true">
 							<p class="advisory">Students and youth with disabilities will be touched by multiple systems, entities and professionals at various times during their movement through secondary education and beyond. For this reason, collaboration and interagency partnerships have long been promoted as essential components of effective transition practice. In fact, there is recent research that suggests that not only is collaboration important, but under the right conditions it can lead to desired outcomes for youth with disabilities in transition from school to careers and adult life.</p>
 							<p class="advisory">This means that various combinations of service components will have to work together on behalf of commonly served youth, with the common goal of adult employment for these youth. These entities can include schools, vocational rehabilitation agencies, intellectual and developmental disabilities agencies, mental health agencies, workforce programs, adult employment programs, public benefits management programs, and other social service programs. For example, one model of seamless transition service collaboration was implemented and studied in 11 school districts in Maryland (Luecking &amp; Luecking, 2015). Through local collaborations and between educators, vocational rehabilitation counselors, adult employment service providers, and other partners, youth eligible for vocational rehabilitation services participated in a sequential series of services that resulted in seamless transition to employment and/or enrollment in postsecondary education or training. One way of depicting the flow of transition services and the accompanying collaboration is adapted from the Maryland demonstration and depicted in Figure 1.</p>
@@ -109,7 +109,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2 class="advisory"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="it-does-not-happen">It does not happen without employers</a></h2>
+						<h2 class="advisory expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="it-does-not-happen">It does not happen without employers</a></h2>
 						<div id="it-does-not-happen" aria-hidden="true">
 							<p class="advisory">Work experiences and jobs for youth only happen when employers are willing to offer these opportunities to them. Therefore, one of the most important skills of transition professionals is the ability to engage employers in this endeavor. How do employers regard youth with disabilities and those transition professionals who support these youth in their pursuit of work experiences? What do employers expect when they agree to host youth for work experiences or to hire them for jobs in their companies? What traits characterize those transition professionals who are most successful at helping youth get and keep jobs? Contemporary research points to key important factors that help answer these questions.</p>
 							<p class="advisory">First, in a recent study conducted by the Center, researchers explored factors contributing to employer decisions to hire youth with disabilities who were participating in the national multi-site transition program called the Bridges… from school to work program (Bridges) administered by the Marriott Foundation for People with Disabilities (Simonsen, Fabian &amp; Luecking, 2015). One hundred (100) employers of Bridges participants responded to a survey designed to measure information about the company, the employer’s perceptions of the hiring process and the role of the employment specialist.</p>
@@ -130,7 +130,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2 class="advisory"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="skilled-transition">It also does not happen without skilled transition professionals</a></h2>
+						<h2 class="advisory expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="skilled-transition">It also does not happen without skilled transition professionals</a></h2>
 						<div id="skilled-transition" aria-hidden="true">
 							<p class="advisory">Students and youth, particularly those who require unusual or extensive support, benefit from assistance from various transition professionals. As they prepare and plan for work experiences and jobs, their success will be largely dependent on the skill and competence of these professionals – professionals who know how to identify students’ best trait  and know how to introduce them to prospective employers. What does it take for these professionals to do this well? What attributes and skills do they need? Again, research points to some answers.</p>
 							<p class="advisory">The Center conducted intensive telephone surveys with employment specialists from the MFPD Bridges program. The professionals who were interviewed worked with youth with a variety of disabilities (including intellectual disabilities, learning disabilities, autism, and emotional disabilities) primarily in urban settings. This program has been in existence since 1989 and has enrolled more than 20,000 youth with disabilities in eight cities over its history to date, with overall job placement and retention rates that exceed 80% in almost all of its locations. It is obvious that the Bridges professionals know what they are doing.</p>
@@ -147,7 +147,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="how-to-use">How to use this Toolkit</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="how-to-use">How to use this Toolkit</a></h2>
 						<div id="how-to-use" aria-hidden="true">
 							<ul class="advisory">
 								<li>Collaborate around the common outcome of integrated paid employment. Effective teams work together to achieve direct outcomes for youth served, rather than simply making a “hand off” to the next available agency or service.</li>
@@ -158,7 +158,7 @@
 					</div>
 					<hr/>
 					<div class="container">
-						<h2><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="references">References</a></h2>
+						<h2 class="expandy-title"><a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="references">References</a></h2>
 						<div id="references" aria-hidden="true">
 							<p class="advisory">Wehman, P., Sima, A., Ketchum, West, M., &amp; Luecking, R. (2014). Journal of Occupational Rehabilitation</p>
 							<a tabIndex="0" class="toggle" role="button" aria-expanded="false" aria-controls="references">Read less &gt;</a>


### PR DESCRIPTION
`h2` elements have a `padding-bottom` set on them which was causing them to have more space below them than above them within the `hr` elements.

To fix this, I created a new CSS class I called `expandy-title` which simply removes this `padding-bottom` by resetting it to `0`. I then went and applied that class to each of those `h2` elements that need this class.

I left a placeholder in style.css for you to go ahead and apply the darker blue color you want to apply to those links.

```css
.expandy-title a {
  /* FIXME:*/
  /* color: SET_THE_COLOR_YOU_WANT_HERE; */
}
```